### PR TITLE
$super 参数的问题

### DIFF
--- a/src/oo.js
+++ b/src/oo.js
@@ -150,7 +150,7 @@ void function (define) {
             constructor: function () {},
             $self: Class,
             $superClass: Object,
-            $super: function (args) {
+            $super: function () {
                 var method = this.$super.caller;
                 var name = method[NAME_PROPERTY_NAME];
                 var superClass = method[OWNER_PROPERTY_NAME].$superClass;
@@ -160,7 +160,7 @@ void function (define) {
                     throw new TypeError('Call the super class\'s ' + name + ', but it is not a function!');
                 }
 
-                return superMethod.apply(this, args);
+                return superMethod.apply(this, arguments);
             }
         };
 


### PR DESCRIPTION
在使用 `$super` 调用父类方法时，现在必须使用完整 `arguments` 作为参数调用。

在某些情况下，可能仅需要使用部分参数，比如

```javascript

var Point = Class({
    constructor: function (x, y) {
        this.x = x;
        this.y = y;
    }
});

var ColorPoint = Class(Point, {
    constructor: function (x, y, color) {
        this.$super(x, y);
        this.color = color;
    }
});
 
```

修改成可供这样调用，感觉灵活度更高，同时也更清晰。